### PR TITLE
fix error when browser does not return os version

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
             var devContainer = document.getElementById('device');
             var devProps = [];
             for (var key in deviceDetails) {
-                devProps.push('<li>' + key + ': <b>' + deviceDetails[key].replace(/(<([^>]+)>)/gi, '') + '</b></li>');
+                devProps.push('<li>' + key + ': <b>' + (deviceDetails[key] ? deviceDetails[key].replace(/(<([^>]+)>)/gi, '') : '') + '</b></li>');
             }
             devContainer.innerHTML = '<ul>' + devProps.join('') + '</ul>';
 


### PR DESCRIPTION
firefox 96.0 ubuntu 18.04 did't load any info. In console it showed `deviceDetails[key] is undefined` in line 156: `devProps.push('<li>' + key + ': <b>' + deviceDetails[key].replace(/(<([^>]+)>)/gi, '') + '</b></li>');`.
After running it locally, it seems that device.os is { name: "Ubuntu", version: undefined }. With the suggestion above any undefined browser info will still work.